### PR TITLE
ajout de la concatenation de artmobilib ainsi que l ecoute des mofifs

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -6,12 +6,14 @@ var sass = require('gulp-sass');
 var minifyCss = require('gulp-minify-css');
 var rename = require('gulp-rename');
 var sh = require('shelljs');
+var uglify = require("gulp-uglify");
 
 var paths = {
-  sass: ['./scss/**/*.scss']
+  sass: ['./scss/**/*.scss'],
+  artmobilib: ['../ArtMobilib/src/**/*.js']
 };
 
-gulp.task('default', ['sass']);
+gulp.task('default', ['sass', 'minify-artmobilib']);
 
 gulp.task('sass', function(done) {
   gulp.src('./scss/ionic.app.scss')
@@ -26,8 +28,15 @@ gulp.task('sass', function(done) {
     .on('end', done);
 });
 
+gulp.task('minify-artmobilib', function () {
+    gulp.src(paths.artmobilib)
+    .pipe(concat('artmobilib.js'))
+    .pipe(gulp.dest('./www/lib/ArtMobilib'));
+});
+
 gulp.task('watch', function() {
   gulp.watch(paths.sass, ['sass']);
+  gulp.watch(paths.artmobilib, ['minify-artmobilib']);
 });
 
 gulp.task('install', ['git-check'], function() {

--- a/ionic.project
+++ b/ionic.project
@@ -1,6 +1,15 @@
 {
   "name": "ArtMobilis",
   "app_id": "",
+  "gulpStartupTasks": [
+    "sass",
+    "watch",
+    "minify-artmobilib"
+  ],
+  "watchPatterns": [
+    "www/**/*",
+    "!www/lib/**/*"
+  ],
   "browsers": [
     {
       "platform": "android",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "gulp-minify-css": "^0.3.0",
     "gulp-rename": "^1.2.0",
     "gulp-sass": "^2.0.4",
+    "gulp-uglify": "^1.5.3",
     "xml2js": "^0.4.16"
   },
   "devDependencies": {


### PR DESCRIPTION
tout est dans le titre mais en gros, ça concatene le code de artmobilib depuis notre depot local en sachant que les deux dépots doivent être côte à côte : 
- ArtMobilis-js/www/lib/ArtMobilis
- ArtMobilib/src

Cette action est effectuée lors d'un "ionic serve".

Pendant l'exécution de "ionic serve", si un fichier du dossier "src" du dépôt ArtMobilib est modifié, le fichier concaténé (ArtMobilis-js/www/lib/ArtMobilis/artmobilis.js) est mis à jour.

Faire un "npm install" la première fois afin que le script installe "gulp-uglify" qui est nécéssaire.

On verra plus tard pour la différence entre dev et prod donc pour le moment, je reste sur la version en clair seulement concaténée et non minimifiée (todo later).
